### PR TITLE
fix: remove the build task from the ci task

### DIFF
--- a/src/lib/tasks/ciTask.ts
+++ b/src/lib/tasks/ciTask.ts
@@ -1,6 +1,5 @@
 import { PropsGlobal, Task } from '../types';
 import analyseTask from './analyseTask';
-import buildTask from './buildTask';
 import depsTask from './depsTask';
 import licenseTask from './licenseTask';
 import testTask from './testTask';
@@ -15,7 +14,6 @@ const ciTask: Task<CiProps> = async (argv) => {
   await testTask(extendArgv, { coverage: true });
   await licenseTask(extendArgv, {});
   await depsTask(extendArgv, {});
-  await buildTask(extendArgv, {});
 };
 
 export default ciTask;


### PR DESCRIPTION
In projects where the build process is already defined, the build task is counterproductive.